### PR TITLE
Resource discovery rt

### DIFF
--- a/lib/david/resource_discovery.rb
+++ b/lib/david/resource_discovery.rb
@@ -1,6 +1,9 @@
+require 'david/server/constants'
+
 module David
   class ResourceDiscovery
     include Celluloid
+    include David::Server::Constants
 
     def initialize(app)
       @app = app

--- a/lib/david/resource_discovery.rb
+++ b/lib/david/resource_discovery.rb
@@ -81,7 +81,9 @@ module David
     end
 
     def routes
-      Rails.application.routes.routes.map do |route|
+      Rails.application.routes.routes.select { |route|
+        route.defaults[:coap]
+      }.map do |route|
         [
           route.path.spec.to_s,
           route.defaults[:controller],

--- a/lib/david/resource_discovery.rb
+++ b/lib/david/resource_discovery.rb
@@ -73,7 +73,7 @@ module David
     end
 
     def include_route?(route)
-      !(route[0] =~ /\A\/(assets|rails)/)
+      !(route[0] =~ /\A\/(assets|rails|cable)/)
     end
 
     def routes

--- a/lib/david/resource_discovery.rb
+++ b/lib/david/resource_discovery.rb
@@ -57,6 +57,10 @@ module David
         .each   { |r| delete_format!(r) }
     end
 
+    def resource_links
+      Hash[routes.collect { |r| [r[3], r[4]] }]
+    end
+
     def delete_format!(route)
       route[0].gsub!(/\(\.:format\)\z/, '')
     end
@@ -81,7 +85,9 @@ module David
         [
           route.path.spec.to_s,
           route.defaults[:controller],
-          route.defaults[:action]
+          route.defaults[:action],
+          route.defaults[:rt],
+          route.defaults[:short]
         ]
       end
     end


### PR DESCRIPTION
This lets one add three attributes to the routes in config/routes.rb:

   coap: true

unless this is set, then the route will not show up in /.well-known/core resource discovery.

   rt: 'string'
   short: '/string'

will return /string as part of a query for /.well-known/core?rt=string.

In addition, the /cable URLs are omitted by default, although perhaps that filter is unimportant given coap: being false by default.
