### PR TITLE
Allow configuration of additional multicast groups

### DIFF
--- a/lib/david/app_config.rb
+++ b/lib/david/app_config.rb
@@ -8,6 +8,7 @@ module David
       :Log => nil,
       :MinimalMapping => false,
       :Multicast => true,
+      :MulticastAddrs => ['ff02::fd', 'ff05::fd'],
       :Observe => true,
       :Port => ::CoAP::PORT
     }
@@ -67,7 +68,11 @@ module David
     def choose_multicast(value)
       default_to_true(:multicast, value)
     end
-    
+
+    def choose_multicastaddrs(value)
+      value
+    end
+
     def choose_observe(value)
       default_to_true(:observe, value)
     end

--- a/lib/david/server/multicast.rb
+++ b/lib/david/server/multicast.rb
@@ -6,7 +6,7 @@ module David
         @socket.to_io.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
 
         if ipv6?
-          maddrs = ['ff02::fd', 'ff05::fd']
+          maddrs = @options[:MulticastAddrs]
           maddrs << 'ff02::1' if OS.osx? # OSX needs ff02::1 explicitly joined.
           maddrs.each { |maddr| multicast_listen_ipv6(maddr) }
 


### PR DESCRIPTION
Previously the multicast groups david joined where hardcoded. This PR allows the caller to specify custom multicast groups david should join. This could for instance be done as follows:

```ruby
# config.ru

# …

David::AppConfig::DEFAULT_OPTIONS[:MulticastAddrs] =
  ["ff02::fd", "ff05::fd", "ff05::158", "ff02::158"]

run myApp
```

I am not sure if it is really a good idea to do this using rack vars, but it works…