### PR TITLE
mapping.rb: fall back to empty string if content format is unknown

### DIFF
--- a/lib/david/server/mapping.rb
+++ b/lib/david/server/mapping.rb
@@ -30,7 +30,8 @@ module David
         if request.accept.nil?
           @options[:DefaultFormat]
         else
-          CoAP::Registry.convert_content_format(request.accept)
+          cf = CoAP::Registry.convert_content_format(request.accept)
+          return cf.nil? ? EMPTY_STRING : cf
         end
       end
 


### PR DESCRIPTION
Without this commit a request might cause a `Rack::Lint::LintError` if the accept option has a value which is unkown to `CoAP::Registry` because the `HTTP_ACCEPT` env variable is set to `nil` then which causes the following exception:

```
Rack::Lint::LintError: env variable HTTP_ACCEPT has non-string value nil
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:20:in `assert'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:274:in `block in check_env'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:272:in `each'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:272:in `check_env'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:43:in `_call'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/lint.rb:37:in `call'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/show_exceptions.rb:23:in `call'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/common_logger.rb:33:in `call'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/chunked.rb:54:in `call'
        /home/rubyuser/.gem/gems/rack-2.0.3/lib/rack/content_length.rb:15:in `call'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server/respond.rb:44:in `respond'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server.rb:102:in `handle_request'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server.rb:93:in `dispatch'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server.rb:46:in `block in run'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server.rb:41:in `loop'
        /home/rubyuser/.gem/gems/david-0.5.1.pre/lib/david/server.rb:41:in `run'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:16:in `dispatch'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
        /home/rubyuser/.gem/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

Not sure if you consider this a bug though since I am not into ruby at all and not sure if `Rack::Lint::LintError` Exceptions are something that just happen in a `:development` rack environment.